### PR TITLE
Fix `this`

### DIFF
--- a/stack.js
+++ b/stack.js
@@ -4,13 +4,14 @@ function Stack(/*layers*/) {
   Array.prototype.slice.call(arguments).reverse().forEach(function (layer) {
     var child = handle;
     handle = function (req, res) {
+      var self = this;
       try {
-        layer(req, res, function (err) {
-          if (err) { return error(req, res, err); }
-          child(req, res);
+        layer.call(this, req, res, function (err) {
+          if (err) { return error.call(self, req, res, err); }
+          child.call(self, req, res);
         });
       } catch (err) {
-        error(req, res, err);
+        error.call(this, req, res, err);
       }
     };
   });


### PR DESCRIPTION
The current behavior loses the original `this` reference after the first layer. A repro case:

```
function layer(req, res, next) {
  console.log(this);
  next();
}
require('http').createServer(
  require('stack')(
    layer,
    layer,
    layer
  )
).listen(80);
```

In the 2nd and 3rd layers, `this` will be "Stack"'s `global` scope. Attached is a fix.
