### PR TITLE
Per-"stack" error handlers

### DIFF
--- a/stack.js
+++ b/stack.js
@@ -4,13 +4,14 @@ function Stack(/*layers*/) {
   Array.prototype.slice.call(arguments).reverse().forEach(function (layer) {
     var child = handle;
     handle = function (req, res) {
+      var self = this;
       try {
-        layer(req, res, function (err) {
-          if (err) { return error(req, res, err); }
-          child(req, res);
+        layer.call(this, req, res, function (err) {
+          if (err) { return error.call(self, req, res, err); }
+          child.call(self, req, res);
         });
       } catch (err) {
-        error(req, res, err);
+        error.call(this, req, res, err);
       }
     };
   });

--- a/stack.js
+++ b/stack.js
@@ -1,19 +1,25 @@
 function Stack(/*layers*/) {
-  var error = Stack.errorHandler,
-      handle = error;
+  function error() {
+    return handle.errorHandler;
+  }
+  var handle = function (req, res, next) {
+    return error().call(this, req, res, next);
+  }
+  handle.__proto__ = Stack;
   Array.prototype.slice.call(arguments).reverse().forEach(function (layer) {
     var child = handle;
     handle = function (req, res) {
       var self = this;
       try {
         layer.call(this, req, res, function (err) {
-          if (err) { return error.call(self, req, res, err); }
+          if (err) { return error().call(self, req, res, err); }
           child.call(self, req, res);
         });
       } catch (err) {
-        error.call(this, req, res, err);
+        error().call(this, req, res, err);
       }
     };
+    handle.__proto__ = child;
   });
   return handle;
 }


### PR DESCRIPTION
Pull this one after the "fix `this`" one.

This commit adds support for an `errorHandler` on a per-"stack" basis.

i.e. the handler function returned from the `Stack` function can accept it's own `errorHandler` function now.

See https://gist.github.com/828899 for a better example.

Cheers!
